### PR TITLE
fix(examples): Windows 运行 build 报错

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -33,11 +33,12 @@
     "@trionesdev/designable-react-settings-form": "^0.0.7-beta.0",
     "@trionesdev/designable-shared": "^0.0.7-beta.0",
     "antd": "^5.8.0",
+    "cross-env": "^7.0.3",
     "requestidlecallback": "^0.3.0"
   },
   "scripts": {
     "start": "craco start",
-    "build": "PUBLIC_URL=. &&  craco build",
+    "build": "cross-env PUBLIC_URL=. craco build",
     "test": "craco test"
   },
   "eslintConfig": {


### PR DESCRIPTION
'PUBLIC_URL' 不是内部或外部命令，也不是可运行的程序或批处理文件